### PR TITLE
Allow Tool Context

### DIFF
--- a/mcp-core/src/tools.rs
+++ b/mcp-core/src/tools.rs
@@ -36,8 +36,12 @@ impl Tools {
     }
 }
 
-pub type ToolHandlerFn =
-    fn(CallToolRequest) -> Pin<Box<dyn Future<Output = CallToolResponse> + Send>>;
+pub type ToolHandlerFn = Box<
+    dyn Fn(CallToolRequest) -> Pin<Box<dyn Future<Output = CallToolResponse> + Send + 'static>>
+        + Send
+        + Sync
+        + 'static,
+>;
 
 pub(crate) struct ToolHandler {
     pub tool: Tool,


### PR DESCRIPTION
The current type definition of `ToolHandlerFn` makes it impossible (well almost except for static variables) to access any context in the tool. E.g. say I want to write a tool that accesses postgres, or a tool that talks to Slack. Any kind of tool that needs *additional* context besides the information that the LLM provides (apart from things like file system which can just be accessed) is not possible because the `Fn` doesn't allow moving in context.

This PR changes that and makes it possible to write a tool such as this:

```
 pub fn call(context: Context) -> ToolHandlerFn {
        Box::new(move |request: CallToolRequest| {
            let clone = context.clone();
            Box::pin(async move {
                let file = match request.get_file() {
                    Ok(file) => file,
                    Err(response) => return response,
                };
```

Thanks for this cool library :) 