### PR TITLE
fix: failed to exit

### DIFF
--- a/mcp-core/Cargo.toml
+++ b/mcp-core/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/stevohuncho/mcp-core"
 readme = "../README.md"
 
 [dependencies]
-tokio = { version = "1.0", features = ["time", "sync", "rt"] }
+tokio = { version = "1.0", features = ["time", "sync", "rt", "io-util", "io-std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/mcp-core/src/transport/server/stdio.rs
+++ b/mcp-core/src/transport/server/stdio.rs
@@ -7,10 +7,11 @@ use crate::types::ErrorCode;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::future::Future;
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 use std::pin::Pin;
 use tokio::time::timeout;
 use tracing::debug;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 #[derive(Clone)]
 pub struct ServerStdioTransport {
@@ -57,10 +58,10 @@ impl Transport for ServerStdioTransport {
     }
 
     async fn poll_message(&self) -> Result<Option<Message>> {
-        let stdin = io::stdin();
-        let mut reader = stdin.lock();
+        let stdin = tokio::io::stdin();
+        let mut reader = BufReader::new(stdin);
         let mut line = String::new();
-        reader.read_line(&mut line)?;
+        reader.read_line(&mut line).await?;
         if line.is_empty() {
             return Ok(None);
         }


### PR DESCRIPTION
Serious MCP server needs a way to exit elegantly but the sync call on the stdin prevents from doing so.