### PR TITLE
fix: increase sse client transport initialization timeout from 1 sec to 10 secs

### DIFF
--- a/mcp-core/Cargo.toml
+++ b/mcp-core/Cargo.toml
@@ -23,7 +23,9 @@ libc = "0.2.170"
 # sse dependencies
 uuid = { version = "1.0", features = ["v4"], optional = true }
 actix-web = { version = "4", optional = true }
-reqwest = { version = "0.12.12", features = ["json"], optional = true }
+reqwest = { version = "0.12.12", default-features = false, features = [
+    "json",
+], optional = true }
 reqwest-eventsource = { version = "0.6.0", optional = true }
 
 [features]

--- a/mcp-core/src/transport/client/sse.rs
+++ b/mcp-core/src/transport/client/sse.rs
@@ -224,7 +224,7 @@ impl Transport for ClientSseTransport {
 
         // Wait for the session URL to be set
         let mut attempts = 0;
-        while attempts < 10 {
+        while attempts < 100 {
             if self.session_endpoint.lock().await.is_some() {
                 return Ok(());
             }


### PR DESCRIPTION
For most MCP servers, a 1-second timeout is insufficient for initialization. This PR increases the timeout to 10 seconds.